### PR TITLE
fix(Button): Improve vertical alignment

### DIFF
--- a/src/ui/components/button/_button.scss
+++ b/src/ui/components/button/_button.scss
@@ -44,7 +44,21 @@
 
   &-text {
     text-align: center;
-    transform: translateY(0.125rem);
+
+    // NOTE: Due to an weird default font's vertical alignment
+    // and since different browsers renders text with different ways
+    // we need to add this two selectors to compensate its height
+    // finding the balance between the line-height and extra pseudo-element
+    &::before {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 2px;
+    }
+
+    &.button {
+      line-height: 0.65;
+    }
   }
 
   @include mq(sm) {


### PR DESCRIPTION
Compensate the different results between browsers when rendering the font family with a pseudo-element on top of its content